### PR TITLE
feat: use AppRun file name as prefix of the .env file path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_C_STANDARD 99)
 if (${CMAKE_BUILD_TYPE} MATCHES Profile)
     message(STATUS "Coverage and profile build flags enabled")
     set(CMAKE_C_FLAGS "-fprofile-arcs -ftest-coverage")
-endif (${CMAKE_BUILD_TYPE} MATCHES Debug)
+endif (${CMAKE_BUILD_TYPE} MATCHES Profile)
 
 add_subdirectory(src)
 

--- a/src/apprun/main.c
+++ b/src/apprun/main.c
@@ -26,9 +26,10 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <libgen.h>
 #include <string.h>
 #include <unistd.h>
+#include <errno.h>
+
 #include "common/string_list.h"
 #include "common/shell_utils.h"
 
@@ -41,13 +42,112 @@
         exit(1);                                    \
     } while(0);
 
-char* get_appdir() {
+char* resolve_apprun_path();
+
+char* find_legacy_env_file(char* apprun_path);
+
+char* build_env_file_path(char* apprun_path, unsigned long i);
+
+char* resole_appdir_path(const char* root_env_file_path);
+
+char* find_module_env_file(char* apprun_path);
+
+void launch();
+
+int main(int argc, char* argv[]) {
+    char* apprun_path = resolve_apprun_path();
+    apprun_env_set("ORIGIN", apprun_path, NULL, apprun_path);
+
+    char* module_env_file_path = find_module_env_file(apprun_path);
+    if (module_env_file_path != NULL)
+        apprun_load_env_file(module_env_file_path, argv);
+
+    if (module_env_file_path == NULL) {
+        char* legacy_env_file_path = find_legacy_env_file(apprun_path);
+        char* appdir_path = resole_appdir_path(legacy_env_file_path);
+
+        apprun_env_set("APPDIR", appdir_path, NULL, appdir_path);
+        apprun_load_env_file(legacy_env_file_path, argv);
+    }
+
+
+    setup_interpreter();
+
+    launch();
+
+    return 1;
+}
+
+char* resole_appdir_path(const char* root_env_file_path) {
     char* appdir = getenv("APPDIR");
-
-    if (appdir == NULL)
-        appdir = dirname(realpath("/proc/self/exe", NULL));
-
+    if (appdir == NULL) {
+        if (root_env_file_path != NULL) {
+            char* idx = strrchr(root_env_file_path, '/');
+            appdir = strndup(root_env_file_path, idx - root_env_file_path);
+        } else {
+            die("Could not resolve APPDIR\n");
+        }
+    }
     return appdir;
+}
+
+char* find_module_env_file(char* apprun_path) {
+    const char apprun_env_extension[] = ".env";
+    const unsigned long apprun_env_extension_len = strlen(apprun_env_extension);
+
+    char* possible_path = malloc(strlen(apprun_path) + apprun_env_extension_len + 1);
+    strcat(possible_path, apprun_path);
+    strncat(possible_path, apprun_env_extension, apprun_env_extension_len);
+
+#ifdef DEBUG
+    fprintf(stderr, "APPRUN_DEBUG: Looking for %s file at: %s\n", apprun_env_extension, possible_path);
+#endif
+    if (access(possible_path, F_OK) == 0)
+        return possible_path;
+    else
+        free(possible_path);
+
+
+    return NULL;
+}
+
+char* resolve_apprun_path() {
+    char* apprun_path = malloc(FILENAME_MAX);
+    memset(apprun_path, 0, FILENAME_MAX);
+    realpath("/proc/self/exe", apprun_path);
+    return apprun_path;
+}
+
+char* find_legacy_env_file(char* apprun_path) {
+    char* slash_idx = strrchr(apprun_path, '/');
+
+    if (slash_idx != NULL) {
+        char* possible_path = build_env_file_path(apprun_path, slash_idx - apprun_path);
+#ifdef DEBUG
+        fprintf(stderr, "APPRUN_DEBUG: Looking for .env file at: %s\n", possible_path);
+#endif
+        if (access(possible_path, F_OK) == 0) {
+            return possible_path;
+        } else {
+            free(possible_path);
+        }
+    }
+
+    return NULL;
+}
+
+
+char* build_env_file_path(char* apprun_path, unsigned long i) {
+    char env_file_name[] = ".env";
+    unsigned long env_file_name_len = 4;
+
+    unsigned possible_path_len = i + env_file_name_len + 2 /*ZERO TERMINATION*/;
+    char* possible_path = calloc(possible_path_len, sizeof(char));
+    memset(possible_path, 0, possible_path_len);
+    strncat(possible_path, apprun_path, i + 1);
+    strncat(possible_path, env_file_name, env_file_name_len);
+
+    return possible_path;
 }
 
 
@@ -63,26 +163,11 @@ void launch() {
         argv[i + 1] = user_args[i];
 
 #ifdef DEBUG
-    fprintf(stderr, "APPRUN_DEBUG:");
+    fprintf(stderr, "APPRUN_DEBUG: executing ");
     for (char** itr = argv; itr != NULL && *itr != NULL; itr++)
         fprintf(stderr, "\"%s\" ", *itr);
     fprintf(stderr, "\n");
 #endif
-    execv(exec_path, argv);
+    int ret = execv(exec_path, argv);
+    fprintf(stderr, "APPRUN_ERROR: %s", strerror(errno));
 }
-
-
-int main(int argc, char* argv[]) {
-    char* appdir = get_appdir();
-    if (!appdir)
-        die("Could not resolve APPDIR\n");
-
-    setup_appdir(appdir);
-    setup_runtime_environment(appdir, argv);
-    setup_interpreter();
-
-    launch();
-
-    return 1;
-}
-

--- a/src/apprun/runtime_environment.h
+++ b/src/apprun/runtime_environment.h
@@ -27,12 +27,10 @@
 #ifndef APPRUN_RUNTIME_ENVIRONMENT_H
 #define APPRUN_RUNTIME_ENVIRONMENT_H
 
+void apprun_env_set(const char* name, const char* value, const char* orig_value, const char* start_value);
+
+void apprun_load_env_file(const char* path, char** argv);
+
 void apprun_update_env(const char* name, const char* value);
-
-char* get_env_file_path(const char* appdir);
-
-void setup_appdir(const char* appdir);
-
-char** setup_runtime_environment(char* appdir, char** argv);
 
 #endif //APPRUN_RUNTIME_ENVIRONMENT_H

--- a/src/common/string_list.c
+++ b/src/common/string_list.c
@@ -111,3 +111,12 @@ char* apprun_string_list_join(char* const* string_list, char* split) {
 
     return str;
 }
+
+char* apprun_prefix_str(const char* prefix, const char* str) {
+    unsigned prefixed_str_size = strlen(prefix) + strlen(str) + 1;
+    char* prefixed_str = calloc(prefixed_str_size, sizeof(char));
+    strcat(prefixed_str, prefix);
+    strcat(prefixed_str, str);
+
+    return prefixed_str;
+}

--- a/src/common/string_list.h
+++ b/src/common/string_list.h
@@ -29,6 +29,8 @@
 
 #include <stdbool.h>
 
+char* apprun_prefix_str(const char* prefix, const char* str);
+
 char** apprun_adjust_string_array_size(char** array);
 
 int apprun_string_list_len(char* const* x);

--- a/src/hooks/environment.c
+++ b/src/hooks/environment.c
@@ -159,7 +159,7 @@ apprun_env_item_t* apprun_env_item_export(apprun_env_item_t* item) {
 
 char* apprun_env_str_entry_extract_name(char* string) {
     if (string) {
-        char* sep = strstr(string, "=");
+        char* sep = strchr(string,  '=');
         return strndup(string, sep - string);
     }
 
@@ -169,7 +169,7 @@ char* apprun_env_str_entry_extract_name(char* string) {
 char* apprun_env_str_entry_extract_value(char* string) {
     if (string && strlen(string) > 0) {
         unsigned string_len = strlen(string);
-        char* sep = strstr(string, "=");
+        char* sep = strchr(string, '=');
         unsigned value_len = string_len - (sep - string);
 
         // assume empty string value as NULL


### PR DESCRIPTION
Goal: Allow defining a different runtime configuration for each binary in a bundle if required.

Features:
- .env file path is created using the AppRun file path as prefix. I.E.: '/AppDir/usr/bin/AppRun.env'
- A new self defined environment variable is introduced ORIGIN which points to the AppRun file.
- AppRun relative .env files must define the APPDIR variable relative to ORIGIN
- Fallback to the legacy implementation and is meant to be a drop in replacement.

Closes #27