### PR TITLE
feat: consider scripts interpreter when guessing the runtime environment to be used

### DIFF
--- a/src/hooks/exec_utils.h
+++ b/src/hooks/exec_utils.h
@@ -27,6 +27,8 @@
 #ifndef APPDIR_RUMTIME_SHARED_H
 #define APPDIR_RUMTIME_SHARED_H
 
+#include <stdbool.h>
+
 #define APPRUN_ENV_APPDIR "APPDIR"
 #define APPRUN_ENV_INTERPRETER "INTERPRETER"
 
@@ -47,5 +49,30 @@ char **apprun_set_original_workdir_env(char *const *envp);
 void chdir_to_runtime();
 
 apprun_exec_args_t *apprun_adjusted_exec_args(const char *filename, char *const *argv, char *const *envp);
+
+/**
+ * Read shebang from file
+ *
+ * @param fd
+ * @return shebang without '#! ' chars (all spaces on left side are removed). Or NULL.
+ */
+char * apprun_read_shebang(const char *filename);
+char *apprun_parse_shebang(char *buf, size_t br);
+
+/**
+ * Extract the interpreter path from shebang line.
+ *
+ * @param shebang
+ * @return interpreter path or NULL
+ */
+char *apprun_shebang_extract_interpreter_path(const char *shebang);
+
+/**
+ * Checks if the interpreter path specified in the shebang is relative to the appdir
+ * @param shebang
+ * @param appdir
+ * @return true if the executable requires an interpreter and if this is relative to the appdir otherwise returns false.
+ */
+bool apprun_shebang_requires_external_executable(const char *shebang, const char *appdir);
 
 #endif //APPDIR_RUMTIME_SHARED_H

--- a/test/hooks/CMakeLists.txt
+++ b/test/hooks/CMakeLists.txt
@@ -1,3 +1,7 @@
+add_executable(exec_utils_tests ./exec_utils_tests.c)
+target_link_libraries(exec_utils_tests PRIVATE apprun_hooks ${CHECK_LIBRARIES} pthread)
+add_test(NAME TEST_EXEC_UTILS COMMAND exec_utils_tests)
+
 add_executable(environment_test environment_test.c ../common/tests_shared.c $<TARGET_OBJECTS:common_objects>)
 target_link_libraries(environment_test apprun_hooks)
 add_test(NAME TEST_ENVIRONMENT COMMAND environment_test)

--- a/test/hooks/exec_utils_tests.c
+++ b/test/hooks/exec_utils_tests.c
@@ -1,0 +1,123 @@
+#include <check.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "hooks/exec_utils.h"
+
+START_TEST (test_apprun_read_shebang_with_args)
+    {
+        char *input = "#! /bin/bash  asd\n";
+        char *output = apprun_parse_shebang(input, 20);
+
+        ck_assert_ptr_ne(output, NULL);
+        ck_assert_str_eq("/bin/bash  asd", output);
+
+        if (output)
+            free(output);
+    }
+END_TEST
+
+START_TEST (test_apprun_read_shebang_without_args)
+    {
+        char *input = "#!  /bin/bash\n";
+        char *output = apprun_parse_shebang(input, 16);
+
+        ck_assert_ptr_ne(output, NULL);
+        ck_assert_str_eq("/bin/bash", output);
+
+        if (output)
+            free(output);
+    }
+END_TEST
+
+START_TEST (test_apprun_read_shebang_from_random_bytes)
+    {
+        char *input = "KAXCJXZCLASKDU";
+        char *output = apprun_parse_shebang(input, 14);
+
+        ck_assert_ptr_eq(output, NULL);
+
+        if (output)
+            free(output);
+    }
+END_TEST
+
+START_TEST (test_apprun_shebang_extract_interpreter_path_from_input_with_spaces)
+    {
+        char *shebang = "/usr/bin/env bash";
+        char *output = apprun_shebang_extract_interpreter_path(shebang);
+        ck_assert_str_eq(output, "/usr/bin/env");
+
+        free(output);
+    }
+END_TEST
+
+START_TEST (test_apprun_shebang_extract_interpreter_path_from_input_without_spaces)
+    {
+        char *shebang = "/usr/bin/env";
+        char *output = apprun_shebang_extract_interpreter_path(shebang);
+        ck_assert_str_eq(output, "/usr/bin/env");
+
+        free(output);
+    }
+END_TEST
+
+
+START_TEST (test_apprun_executable_requires_external_interp)
+    {
+        char *shebang = "/usr/bin/env";
+        bool r = apprun_shebang_requires_external_executable(shebang, "/usr/bin");
+        ck_assert_int_eq(r, false);
+    }
+END_TEST
+
+START_TEST (test_apprun_executable_requires_external_interp_fail)
+    {
+        char *shebang = "/usr/bin/env";
+        bool r = apprun_shebang_requires_external_executable(shebang, "/opt");
+        ck_assert_int_eq(r, true);
+    }
+END_TEST
+
+Suite *exec_utils_suite(void) {
+    Suite *s;
+    TCase *tc_read_shebang;
+    TCase *tc_extract_interpreter_path;
+    TCase *tc_apprun_executable_requires_external_interp;
+
+
+    s = suite_create("Exec Utils");
+
+    /* Core test case */
+    tc_read_shebang = tcase_create("apprun_parse_shebang");
+    tcase_add_test(tc_read_shebang, test_apprun_read_shebang_with_args);
+    tcase_add_test(tc_read_shebang, test_apprun_read_shebang_without_args);
+    tcase_add_test(tc_read_shebang, test_apprun_read_shebang_from_random_bytes);
+    suite_add_tcase(s, tc_read_shebang);
+
+    tc_extract_interpreter_path = tcase_create("apprun_shebang_extract_interpreter_path");
+    tcase_add_test(tc_extract_interpreter_path, test_apprun_shebang_extract_interpreter_path_from_input_with_spaces);
+    tcase_add_test(tc_extract_interpreter_path, test_apprun_shebang_extract_interpreter_path_from_input_without_spaces);
+    suite_add_tcase(s, tc_extract_interpreter_path);
+
+    tc_apprun_executable_requires_external_interp = tcase_create("apprun_shebang_requires_external_executable");
+    tcase_add_test(tc_apprun_executable_requires_external_interp, test_apprun_executable_requires_external_interp);
+    tcase_add_test(tc_apprun_executable_requires_external_interp, test_apprun_executable_requires_external_interp_fail);
+    suite_add_tcase(s, tc_apprun_executable_requires_external_interp);
+
+    return s;
+}
+
+int main(void) {
+    int number_failed;
+    Suite *s;
+    SRunner *sr;
+
+    s = exec_utils_suite();
+    sr = srunner_create(s);
+
+    srunner_run_all(sr, CK_NORMAL);
+    number_failed = srunner_ntests_failed(sr);
+    srunner_free(sr);
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
scripts using an external interpreter need to be executed using the system runtime otherwise the libraries may crash