### PR TITLE
Add NULL check to `find_hooked_symbol`

### DIFF
--- a/src/common/hook_debug.c
+++ b/src/common/hook_debug.c
@@ -46,7 +46,7 @@ char *find_hooked_symbol() {
         perror("backtrace_symbols");
         exit(EXIT_FAILURE);
     }
-    char *apprun_hooks_entry;
+    char *apprun_hooks_entry = NULL;
     for (int j = 0; j < nptrs; j++) {
         if ((strstr(strings[j], "libapprun_hooks.so") != NULL)
             && (strstr(strings[j], "__libc_start_main") == NULL)
@@ -55,7 +55,7 @@ char *find_hooked_symbol() {
         }
     }
 
-    char *symbol_name_being = strstr(apprun_hooks_entry, "(");
+    char *symbol_name_being = apprun_hooks_entry != NULL ? strstr(apprun_hooks_entry, "(") : NULL;
 
     // symbol name lookup is not perfect, in case of failure just return UNKNOWN
     if (symbol_name_being == NULL)


### PR DESCRIPTION
On QEMU User ARM32, missing this NULL check would cause a segmentation fault.

```
(gdb) bt
#0  0xfe586c20 in strchr () from /squashfs-root//opt/libc/lib/arm-linux-gnueabihf/libc.so.6
#1  0xfe79677e in find_hooked_symbol () at /home/user/Documents/mcpi/AppRun/src/common/hook_debug.c:58
#2  0xfe79543c in redirect_path_full (pathname=0xfe796a84 "/proc/self/exe", check_parent=0, only_if_absolute=0) at /home/user/Documents/mcpi/AppRun/src/hooks/redirect_path.c:90
#3  0xfe795642 in apprun_redirect_path (pathname=0xfe796a84 "/proc/self/exe") at /home/user/Documents/mcpi/AppRun/src/hooks/redirect_path.c:159
#4  0xfe7952a8 in realpath (name=0xfe796a84 "/proc/self/exe", resolved=0xfefd3814 "") at /home/user/Documents/mcpi/AppRun/src/hooks/hooks.c:490
#5  0xfe793fe4 in apprun_main_hook (argc=1, argv=0xfefd49c4, envp=0xfefd49cc) at /home/user/Documents/mcpi/AppRun/src/hooks/main_hook.c:24
#6  0xfe543a20 in __libc_start_main () from /squashfs-root//opt/libc/lib/arm-linux-gnueabihf/libc.so.6
#7  0xfe794100 in __libc_start_main (main=0xfefd76e1 <main>, argc=1, argv=0xfefd49c4, init=0xfefdc341 <__libc_csu_init>, fini=0xfefdc381 <__libc_csu_fini>, rtld_fini=0xfe7b6075, stack_end=0xfefd49c4)
    at /home/user/Documents/mcpi/AppRun/src/hooks/main_hook.c:60
#8  0xfefd7e24 in _start ()
```